### PR TITLE
fix: support empty config & add tip for windows

### DIFF
--- a/agent.js
+++ b/agent.js
@@ -1,19 +1,26 @@
 'use strict';
 
-const assert = require('assert');
 const AlinodeAgent = require('agentx');
 const homedir = require('node-homedir');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 
 module.exports = agent => {
   const config = agent.config.alinode;
+  const platform = (os.platform() || '').toLowerCase();
   if (!config.enable) {
     agent.coreLogger.info('[egg-alinode] disable');
     return;
   }
-  assert(config.appid, 'config.alinode.appid required');
-  assert(config.secret, 'config.alinode.secret required');
+  if (!config.appid || !config.secret) {
+    agent.coreLogger.info('[egg-alinode] config.alinode.appid && config.alinode.secret required');
+    return;
+  }
+  if (platform === 'win32') {
+    agent.coreLogger.info('[egg-alinode] alinode does not support windows for the time being.');
+    return;
+  }
 
   const nodepathFile = path.join(homedir(), '.nodepath');
   const nodeBin = path.dirname(process.execPath);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
No

##### Description of change
<!-- Provide a description of the change below this comment. -->
1.当在特定的服务器或环境下不想使用alinode，通过修改config.[env].js中appid或secret为空即可，不需要修改config/plugin.js

2.windows启动报'getconf'命令错误，运行过程中持续报'\node_modules\commandx\get_processes_count ENOENT'错误，修改后windows环境不实例化AlinodeAgent，只通过logger记录
